### PR TITLE
Update readme.MD with new instructions for Megan version in Atom, fix app.js errors, add gitignore for npm packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 var express = require('express');
 // var port = process.env.port || 8080; // 8080 for local or whatever number u want
 // var listener = app.listen(port, function(){
-//     console.log('Listening on port ' + port); 
+//     console.log('Listening on port ' + port);
 // });
 var path = require('path');
 var favicon = require('serve-favicon');
@@ -18,6 +18,10 @@ var qualify = require('./routes/qualify');
 var lodash = require('lodash');
 
 var app = express();
+ var port = process.env.port || 8080; // 8080 for local or whatever number u want
+ var listener = app.listen(port, function(){
+     console.log('Listening on port ' + port);
+ });
 
 // view engine setup
 app.set('views', path.join(__dirname, 'views'));

--- a/readme.MD
+++ b/readme.MD
@@ -1,36 +1,34 @@
 
 <h1> Fork this  Megan Repository to start building on top of it <br> </h1>
--- Megan rep --https://github.com/maggienj/Megan <br> 
+-- Megan rep --https://github.com/maggienj/Megan <br>
 -- Prince_housing --https://github.com/maggienj/Prince_housing <br> ( this is a previous version v0.1... using node and angular )
 
-To run Megan app folow these steps: <br>
+To run Megan app follow these steps: <br>
 1. Fork Megan Repository
-2. Open web app in Jetbrains IDE (or any preferred IDE) 
+2. Open web app in Jetbrains IDE (or any preferred IDE)
 3. Run app
 
-To run prince_housing app follow these steps: <br>  First of all fork it.... <br>
-To run the app locally: <br> 
-0. Make sure"npm install -g" inside /Prince_housing <br>
-1. make sure you have node.js installed <br>
-2. install 'express' by running "npm install express -g" inside /Prince_housing. <br>
-2. navigate to /Prince_housing in the terminal <br>
-3. run: node app.js <br>
-4. open chrome to localhost:8080 <br> 
-5. Now you should be able to view the initial desgin of the app. <br>
-6. If you get any errs then, ensure you have express installed as part of the node modules. <br>
+To run the Megan app using Atom as your preferred editor: <br>
+1. Fork the Megan repository to your personal github account
+2. Clone your copy of the Megan repository to your dev machine
+3. Make sure you have npm installed on your machine
+4. Install 'express.js' by running <code>npm install express -g</code> inside the /Megan folder from a terminal. <br>
+5. Also inside the /Megan folder, run <code>npm install</code>
+6. In the same folder, run: <code>node app.js</code> <br>
+7. Open a web browser to <code>http://localhost:8080</code> and start coding!<br>
 
 <br>
 ** Affordable Housing Project **
-> -- using the code for America template <br> 
+> -- using the code for America template <br>
 https://docs.google.com/document/d/1KaApjflNS7NRHaEGEZGmotNzi27TqshKtoCn12L6I0g/edit?usp=sharing
 
-** References ** 
+** References **
 > Any references, data sources, articles, additional documents, etc. <br>
-> https://github.com/maggienj/Prince_housing/blob/master/Outline_forDan.txt <br> 
-> https://github.com/maggienj/Prince_housing/blob/master/lookupData_info.txt <br> 
-> https://github.com/maggienj/Prince_housing/blob/master/nj-housing-incomelimits.pdf <br> 
+> https://github.com/maggienj/Prince_housing/blob/master/Outline_forDan.txt <br>
+> https://github.com/maggienj/Prince_housing/blob/master/lookupData_info.txt <br>
+> https://github.com/maggienj/Prince_housing/blob/master/nj-housing-incomelimits.pdf <br>
 
-** June 9 - 2016 ** 
+** June 9 - 2016 **
 Transformation of lookup data.  From PDF to CSV to JSON - Done! <br>
 
 Use this latest uploaded JSON file. (lkpDataV3.json) <br>
@@ -46,7 +44,7 @@ Converter Used : http://codebeautify.org/csv-to-xml-json <br><br>
 For the upcoming hackathon June 10 , 2016 <br>
 -- Notes by MaggieNJ -- Jun 10 , 2016 --- <br>
 ** the below link contains a nodejs web app which uses the above json file. <br>
-https://github.com/maggienj/Megan <br> 
+https://github.com/maggienj/Megan <br>
 It uses lodash to filter and query the above lookup data json file. The code for it is in app.js <br>
 The next step is to move that section of code to "qualify" page and set that as an action for submit button with few more modifications
 <br>
@@ -54,38 +52,38 @@ The next step is to move that section of code to "qualify" page and set that as 
 ** Next set of tasks are listed here. Keep updating the status as you complete each one of these tasks.
 <br>
 * If multiple people working on this , then, distribute these steps to individuals for faster completion. <br>
-* If not mulitples (solo),  then execute these steps in the same order... The last step is to beautify it. 
+* If not mulitples (solo),  then execute these steps in the same order... The last step is to beautify it.
 * Fork this repository to your github repo and start working on each and every step<br>
 -- Task#1 -- Move the section of code related to lodash and lookup data json parsing to "qualify" page.
 <br>
------- Status -- 
+------ Status --
 <br> <br>
 -- Task#2 -- Get the submit button working in "qualify" page.
 <br>
------- Status -- 
+------ Status --
 <br><br>
--- Task#3 -- Instead of Zip code, add the county name in a pul down list.  List only Mercer , Monmouth and Ocean county names. 
+-- Task#3 -- Instead of Zip code, add the county name in a pul down list.  List only Mercer , Monmouth and Ocean county names.
 <br>
------- Status -- 
+------ Status --
 <br> <br>
 -- Task#4 -- Add "Type" as an input field to "qualify page".  Use drop down list.  Values for the drop down list are, Median, Moderate, Low and Very Low.  ( Currently, I have hard coded "Moderate"  in app.js , remove this hard coding and accept it from the user directly)
-<br> 
------- Status --
-<br> <br>
--- Task#5 -- Once the submit button in "qualify page" is clicked, it should lookup the json file and output the result as "You are eligible for Affordable Housing in Princeton" or ....... 
 <br>
 ------ Status --
 <br> <br>
--- 
+-- Task#5 -- Once the submit button in "qualify page" is clicked, it should lookup the json file and output the result as "You are eligible for Affordable Housing in Princeton" or .......
+<br>
+------ Status --
+<br> <br>
 --
--- Task#99 -- Beautify the layout with bootsrap. Bootstrap css, js and fonts have been downloaded and placed in css, js and fonts directory. Use the Jumbotron wide template for responsive websites. The meta tag has been added to make it as a responsive website to show legibly in all devices. Continue on this and build this as a responsive website.. 
+--
+-- Task#99 -- Beautify the layout with bootsrap. Bootstrap css, js and fonts have been downloaded and placed in css, js and fonts directory. Use the Jumbotron wide template for responsive websites. The meta tag has been added to make it as a responsive website to show legibly in all devices. Continue on this and build this as a responsive website..
 
 
 For the upcoming hackathon June 10 , 2016 <br>
 ----------------------------------------- <br>
 We need members to complete the above steps <br>
 We need members to prepare a ppt to explain about Aff Housing <br>
-We need members to present this ppt and the website on Sunday. <br> 
+We need members to present this ppt and the website on Sunday. <br>
 
 If you would like to take part in this AffHousing project, then let me know which task you would like to contribute on.
 
@@ -102,4 +100,3 @@ http://www.princetonnj.gov/affordable/AffordableHousing_Application.pdf
 Aug 27 update:
 We have received the pdf forms from Melissa, but they were scanned paper forms.
 We have requested for the actual digital pdf form so that we could create fields and auto populate the values form html form
-

--- a/readme.MD
+++ b/readme.MD
@@ -4,19 +4,19 @@
 -- Prince_housing --https://github.com/maggienj/Prince_housing <br> ( this is a previous version v0.1... using node and angular )
 
 To run Megan app follow these steps: <br>
-1. Fork Megan Repository
-2. Open web app in Jetbrains IDE (or any preferred IDE)
-3. Run app
+1. Fork Megan Repository <br>
+2. Open web app in Jetbrains IDE (or any preferred IDE) <br>
+3. Run app <br>
 
 To run the Megan app using Atom as your preferred editor: <br>
-1. Fork the Megan repository to your personal github account
-2. Clone your copy of the Megan repository to your dev machine
-3. Make sure you have npm installed on your machine
+1. Fork the Megan repository to your personal github account <br>
+2. Clone your copy of the Megan repository to your dev machine <br>
+3. Make sure you have npm installed on your machine <br>
 4. Install 'express.js' by running <code>npm install express -g</code> inside the /Megan folder from a terminal. <br>
-5. Also inside the /Megan folder, run <code>npm install</code>
+5. Also inside the /Megan folder, run <code>npm install</code> <br>
 6. In the same folder, run: <code>node app.js</code> <br>
 7. Open a web browser to <code>http://localhost:8080</code> and start coding!<br>
-
+<br>
 <br>
 ** Affordable Housing Project **
 > -- using the code for America template <br>


### PR DESCRIPTION
I had to update app.js to have it run out of the box on port 8080 with the 'node app.js' command.

I also made up some new getting started instructions for folks who may prefer the Atom IDE (or any other lightweight IDE) over jetbrains.

Finally I added a .gitignore file for the node_modules folder so every time someone works on the project they dont accidentally push up all of their local node packages.